### PR TITLE
Add code for parsing configs into python data classes

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,15 @@
 			"settings": {
 				"yaml.schemas": {
 					"file:///workspaces/confidential-server/src/config/schema.yml": "file:///**/examples/**/*.yml"
-				}
+				},
+				"files.exclude": {
+					"**/__pycache__": true
+				},
+				"python.testing.pytestArgs": [
+					"test"
+				],
+				"python.testing.unittestEnabled": false,
+				"python.testing.pytestEnabled": true
 			}
 		}
 	},

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  lint-configs:
+  test-config:
     runs-on: ubuntu-latest
 
     steps:
@@ -19,4 +19,4 @@ jobs:
 
     - run: pip install -r test/requirements.txt
 
-    - run: pytest -sv test/config/test_config_schema.py
+    - run: pytest -sv test/config

--- a/src/config/parse.py
+++ b/src/config/parse.py
@@ -1,0 +1,70 @@
+
+
+import os
+import yaml
+import re
+from dataclasses import dataclass
+from typing import Dict, List, Union
+
+
+@dataclass
+class ServerTargetConfig:
+    path: str
+    policies: Union[str, List[str]]
+
+    def _validate_path(self):
+        if not isinstance(self.path, str):
+            raise ValueError("Path must be a string.")
+        if not os.path.exists(self.path):
+            raise FileNotFoundError(f"Path '{self.path}' does not exist.")
+        if not os.access(self.path, os.R_OK):
+            raise PermissionError(f"Path '{self.path}' is not readable.")
+
+    def _validate_policies(self):
+        if isinstance(self.policies, list):
+            if not all(isinstance(item, str) for item in self.policies):
+                raise ValueError("Each policy in the list must be a string.")
+        elif not isinstance(self.policies, str):
+            raise ValueError("Policies must be either a string or a list of strings.")
+
+    def __post_init__(self):
+        self._validate_path()
+        self._validate_policies()
+
+
+@dataclass
+class ServerConfig:
+    serve: List[ServerTargetConfig]
+    security_policies: Dict[str, str]
+
+    def _validate_target_configs(self):
+        if not isinstance(self.serve, list):
+            raise ValueError("Serve must be a list of ServerTargetConfig.")
+        for target in self.serve:
+            if not isinstance(target, ServerTargetConfig):
+                raise ValueError("Each item in serve must be a ServerTargetConfig instance.")
+            if isinstance(target.policies, str):
+                if target.policies not in self.security_policies:
+                    raise ValueError(f"Policy '{target.policies}' not found in security policies.")
+            elif isinstance(target.policies, list):
+                for policy in target.policies:
+                    if policy not in self.security_policies:
+                        raise ValueError(f"Policy '{policy}' not found in security policies.")
+
+    def _validate_security_policies(self):
+        for key, value in self.security_policies.items():
+            if not isinstance(value, str):
+                raise ValueError(f"Security policy for '{key}' must be a string.")
+            if not re.compile(r'^[A-Za-z0-9+/]+={0,2}$').fullmatch(value):
+                raise ValueError(f"The security policy value for '{key}' does not match the required pattern.")
+
+    def __post_init__(self):
+        self.serve = [ServerTargetConfig(**target) for target in self.serve]
+        self._validate_target_configs()
+        self._validate_security_policies()
+
+
+def parse_config_file(config_path):
+    if os.path.isfile(config_path):
+        with open(config_path) as f:
+            return ServerConfig(**yaml.safe_load(f))

--- a/test/config/test_config_parser.py
+++ b/test/config/test_config_parser.py
@@ -1,0 +1,50 @@
+import pytest
+from utils import configs
+import yaml
+from src.config.parse import parse_config_file
+import tempfile
+
+
+@pytest.mark.parametrize("config", configs(), ids=lambda c: c[1])
+def test_example_config_parses_without_error(config):
+    parse_config_file(config[1])
+
+
+def test_config_with_mismatched_policy_name():
+
+    with tempfile.NamedTemporaryFile("w", prefix="config_") as f:
+        yaml.dump({
+            "serve": [
+                {
+                    "path": "readme.md",
+                    "policies": "not_a_policy"
+                }
+            ],
+            "security_policies": {
+                "allow_all": "abc123"
+            }
+        }, f)
+        f.flush()
+
+        with pytest.raises(ValueError, match="Policy 'not_a_policy' not found in security policies."):
+            parse_config_file(f.name)
+
+
+def test_config_with_non_existing_file():
+
+    with tempfile.NamedTemporaryFile("w", prefix="config_") as f:
+        yaml.dump({
+            "serve": [
+                {
+                    "path": "not_a_file.md",
+                    "policies": "allow_all"
+                }
+            ],
+            "security_policies": {
+                "allow_all": "abc123"
+            }
+        }, f)
+        f.flush()
+
+        with pytest.raises(FileNotFoundError, match="Path 'not_a_file.md' does not exist."):
+            parse_config_file(f.name)

--- a/test/config/test_config_schema.py
+++ b/test/config/test_config_schema.py
@@ -1,21 +1,13 @@
-import os
 import pytest
 import yaml
-import glob
 from jsonschema import validate
+from utils import configs
 
 
 @pytest.fixture
 def schema():
     with open("src/config/schema.yml") as f:
         return yaml.safe_load(f)
-
-
-def configs():
-    for config_path in glob.glob("examples/config/*.yml"):
-        if os.path.isfile(config_path):
-            with open(config_path) as f:
-                yield yaml.safe_load(f), config_path
 
 
 @pytest.mark.parametrize("config", configs(), ids=lambda c: c[1])

--- a/test/config/utils.py
+++ b/test/config/utils.py
@@ -1,0 +1,10 @@
+import glob
+import os
+import yaml
+
+
+def configs():
+    for config_path in glob.glob("examples/config/*.yml"):
+        if os.path.isfile(config_path):
+            with open(config_path) as f:
+                yield yaml.safe_load(f), config_path

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,7 @@
+import sys
+import os
+
+# Add the project root directory to sys.path
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)


### PR DESCRIPTION
### Why

Partly addresses #4 

### How
- [x] Add data classes for configuration files
- [x] Add testing for the parser

The fact that example configs are tested against both the schema and the parser keeps the two in sync