### PR TITLE
Add a clang-tidy config file

### DIFF
--- a/tools/c-aci-attestation/.clang-tidy
+++ b/tools/c-aci-attestation/.clang-tidy
@@ -1,0 +1,2 @@
+Checks: 'clang-diagnostic-*,clang-analyzer-*,-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling'
+WarningsAsErrors: true


### PR DESCRIPTION
### Why

We have a lot of fprintf() calls which violates DeprecatedOrUnsafeBufferHandling, for now I think it's better to suppress the warning, we might want to update the toolchain to support fprintf_s() but not for now
