### PR TITLE
Add pip and github actions to dependabots package ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,27 @@
 
 version: 2
 updates:
- - package-ecosystem: "devcontainers"
-   directory: "/"
-   schedule:
-     interval: weekly
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "13:00"
+    open-pull-requests-limit: 10
+    reviewers:
+    - domayre
+    allow:
+    - dependency-type: direct
+    - dependency-type: indirect
+    commit-message:
+      prefix: "fix: "
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "13:00"
+    commit-message:
+      prefix: "fix: "
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    schedule:
+      interval: weekly


### PR DESCRIPTION
### Why

Since we use external packages from pip and GitHub Actions, dependabot should be able to update those